### PR TITLE
add fail_render option to override default 404

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -14,6 +14,8 @@ example/showoff-authorization.pl
 lib/Mojolicious/Plugin/Authorization.pm
 t/00-load.t
 t/01-functional.t
+t/03-no_config.t
+t/04-full_fat_app.t
 t/manifest.t
 t/release-cpan-changes.t
 weaver.ini

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,6 +9,8 @@ my %WriteMakefileArgs = (
     "Mojolicious::Lite" => 0,
     "Test::Mojo" => 0,
     "Test::More" => 0,
+    'Test::Exception' => 0.32,
+    'Test::Deep'      => 0.113,
     "strict" => 0,
     "warnings" => 0
   },

--- a/t/03-no_config.t
+++ b/t/03-no_config.t
@@ -1,0 +1,36 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Mojolicious::Lite;
+use Test::More;
+use Test::Exception;
+
+my $plugin_config = {};
+
+for my $required_param ( qw/ has_priv is_role user_privs user_role / ) {
+  if ( ! keys %{ $plugin_config } ) {
+    throws_ok(
+      sub { plugin 'authorization' },
+      qr/missing '$required_param' subroutine ref in parameters/,
+      "plugin with no config croaks",
+    );
+  }
+  throws_ok(
+    sub { plugin 'authorization' => $plugin_config; },
+    qr/missing '$required_param' subroutine ref in parameters/,
+    "plugin with no '$required_param' config croaks",
+  );
+  $plugin_config->{$required_param} = "not a code ref";
+  throws_ok(
+    sub { plugin 'authorization' => $plugin_config; },
+    qr/missing '$required_param' subroutine ref in parameters/,
+    "plugin with none code ref '$required_param' config croaks",
+  );
+  $plugin_config->{$required_param} = sub {};
+}
+
+done_testing();
+
+# vim: ts=2:sw=2:et

--- a/t/04-full_fat_app.t
+++ b/t/04-full_fat_app.t
@@ -1,0 +1,72 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+# testing in a "full fat" Mojolicious app, and also that we can
+# return status codes other than the default 404 not found when
+# users lack privs/roles
+
+package FullFatAuth;
+
+use Mojo::Base qw( Mojolicious );
+
+sub startup {
+  my ( $self ) = @_;
+
+  $self->plugin(
+    'authorization' => {
+      has_priv    => sub { 0 },
+      is_role     => sub { 0 },
+      user_privs  => sub { {} },
+      user_role   => sub { undef },
+      fail_render => { status => 401, json => { error => 'Denied' } },
+    }
+  );
+
+  $self->routes->any('/cake/make')
+    ->over(has_priv => 'cake:eat')
+    ->to('Public#eat_cake')
+  ;
+
+  $self->routes->any('/cake/eat')
+    ->over(is_role => 'chef')
+    ->to('Public#make_cake')
+  ;
+}
+
+package FullFatAuth::Public;
+
+use Mojo::Base 'Mojolicious::Controller';
+
+package main;
+
+use strict;
+use warnings;
+
+use Test::Mojo;
+use Test::More;
+use Test::Deep;
+use Mojolicious::Commands;
+
+my $t = Test::Mojo->new( 'FullFatAuth' );
+
+$t->get_ok( '/cake/make' )->status_is( 401 );
+
+cmp_deeply(
+  $t->tx->res->json,
+  { error => 'Denied' },
+  'has_priv failure renders custom response',
+);
+
+$t->get_ok( '/cake/eat' )->status_is( 401 );
+
+cmp_deeply(
+  $t->tx->res->json,
+  { error => 'Denied' },
+  'is_role failure renders custom response',
+);
+
+done_testing();
+
+# vim: ts=2:sw=2:et


### PR DESCRIPTION
if your API is a fully documented public API then you're not really
bothered about revealing information to hackers as the API is fully
documented anyway. in this case returning a 404 to the user is not
helpful to enable them to debug reasons for failure, and returning
a 401 with a descriptive error is more useful

support a fail_render config option to allow users of the plugin to
return a custom status code and render json/text/etc when routing
fails due to has_priv/is/is_role failures

slight refactoring in args checking and helper initialization to
remove duplicate code

update perldoc to reflect above changes, add tests for this and also
add tests to check calling the plugin without config settings shows
expected errors

test coverage in this change is increased to full stmt, bran, and
sub coverage, cond coverage is increased from 45% to 70%:

...ious/Plugin/Authorization.pm  100.0  100.0   70.5  100.0   93.3